### PR TITLE
Transmo extra tinker inv

### DIFF
--- a/data/birth/gnome.lua
+++ b/data/birth/gnome.lua
@@ -213,7 +213,7 @@ if orcs then
 			_t"Iron Gnomes are tough and strong. They are small, but are quite resilient.",
 			_t"They know Conditioning and Blacksmith.",
 			_t"",
-			_t"#GOLD#Stat modifiers:#LIGHT_BLUE# +2 Cunning, +2 Strength",
+			_t"#GOLD#Stat modifiers:#LIGHT_BLUE# +2 Strength, +2 Cunning",
 			_t"#GOLD#Life per level:#LIGHT_BLUE# 14",
 		},
 		power_source = {technique=true},

--- a/data/birth/gnome.lua
+++ b/data/birth/gnome.lua
@@ -175,8 +175,9 @@ if orcs then
 			moddable_tile_base = "base_gnome.png",
 			moddable_tile = "halfling_#sex#", --piggyback on halfling art
 			resolvers.inventory{ id=true,
-				{defined="ORB_SCRYING"},
 				{defined="APE", base_list="mod.class.Object:/data-orcs/general/objects/quest-artifacts.lua"},
+			},
+			resolvers.inventory{ id=true, transmo=true,
 				{type="scroll", subtype="implant", name="steam generator implant", base_list="mod.class.Object:/data-orcs/general/objects/inscriptions.lua", autoreq=true, ego_chance=-1000},
 				{type="scroll", subtype="implant", name="medical injector implant", base_list="mod.class.Object:/data-orcs/general/objects/inscriptions.lua", autoreq=true, ego_chance=-1000},
 				{type="scroll", subtype="implant", name="medical injector implant", base_list="mod.class.Object:/data-orcs/general/objects/inscriptions.lua", autoreq=true, ego_chance=-1000},

--- a/superload/data/talents/spells/golemancy.lua
+++ b/superload/data/talents/spells/golemancy.lua
@@ -53,7 +53,7 @@ Talents.talents_def.T_REFIT_GOLEM.invoke_golem = function(self, t, birth) --luac
 		}
 		self.alchemy_golem.talents_types_mastery = {
 			["golem/fighting"] = 0,
-			["golem/arcane"] = -0,
+			["golem/arcane"] = 0,
 		}
 
 		if self.descriptor.subrace == "Garden Gnome" then
@@ -86,14 +86,12 @@ local learn_old = Talents.talents_def.T_GOLEM_POWER.on_learn
 local unlearn_old = Talents.talents_def.T_GOLEM_POWER.on_unlearn
 
 Talents.talents_def.T_GOLEM_POWER.on_learn = function(self, t)
-	if not self.alchemy_golem then return end -- Safety net
 	learn_old(self, t)
 	if self.descriptor.subrace == "Tinker Gnome" then
 		self.alchemy_golem:learnTalent(Talents.T_STEAMSAW_MASTERY, true, nil, {no_unlearn=true})
 	end
 end
 Talents.talents_def.T_GOLEM_POWER.on_unlearn = function(self, t)
-	if not self.alchemy_golem then return end -- Safety net
 	unlearn_old(self, t)
 	if self:getTalentLevelRaw(t) == 0 and not self.innate_alchemy_golem then
 		self:unlearnTalent(self.T_REFIT_GOLEM)


### PR DESCRIPTION
Fix iron gnomes stat description, set starting steam generator and injectors on tinker gnome to be marked for transmutation, and take out safety net lines that prevent classes that don't start with golem from learning golemancy.